### PR TITLE
Remove admin claim for viewing quiz enrolments and quizzes #264

### DIFF
--- a/service/src/resolvers/queryResolvers.ts
+++ b/service/src/resolvers/queryResolvers.ts
@@ -153,7 +153,7 @@ const queryResolvers: QueryResolvers = {
     quizzes: admin(quizzesQuery),
     user: admin(userQuery),
     userQuiz: admin(userQuizQuery),
-    userQuizzes: admin(userQuizzesQuery),
+    userQuizzes: user(userQuizzesQuery),
     users: admin(usersQuery),
 }
 


### PR DESCRIPTION
**Issue**

Admin claim to view quiz enrolments and quizzes is not needed. 

Closes #264 

**Solution**
Change scope for viewing quiz enrolments and quizzes from admin to user. 

**Risk**

No risks. 

**Reviewers**

@johnchen383 
@bcho892 