### PR TITLE
fix: account for all parameters in submitUserQuizQuestionsMutation

### DIFF
--- a/service/src/resolvers/mutationResolvers.ts
+++ b/service/src/resolvers/mutationResolvers.ts
@@ -429,7 +429,7 @@ const submitUserQuizQuestionsMutation: Resolver<
         throw new AuthenticationError()
     }
     // flag quiz as submitted
-    editUserQuiz(userQuizID, undefined, undefined, undefined, true);
+    editUserQuiz(userQuizID, undefined, undefined, undefined, undefined, true)
 
     const { userAnswerIDs, correctAnswerIDs } = await getUserAnswers(userQuizID)
 


### PR DESCRIPTION
**Issue**

<!-- Explain why you're making the change you are, what is the problem this PR solves? -->

Fixes crash called by the submit quiz mutation not accounting for the new changes made by #385 

**Risks**

<!-- Explain the risks with merging this PR. -->

**Reviewers**

<!-- Add a list of random people and also add them at the top right. -->