### PR TITLE
409 cascading deletion

### DIFF
--- a/client/src/components/app/admin/QuizManagement.vue
+++ b/client/src/components/app/admin/QuizManagement.vue
@@ -146,7 +146,7 @@
         <v-btn @click="enrollUserIntoQuiz" block size="large" color="white" :disabled="loading"
           >ENROLL STUDENTS TO EXAM (UPLOAD CSV)<v-icon end icon="mdi-paperclip"></v-icon
         ></v-btn>
-        <v-file-input ref="csvUploadZone" class="d-none" type="file" @input="handleCsvUpload" />
+        <v-file-input ref="csvUploadZone" class="d-none" type="file" accept=".csv" @input="handleCsvUpload" />
         <v-btn
           @click="downloadUserQuizzes"
           block

--- a/client/src/components/app/admin/QuizManagement.vue
+++ b/client/src/components/app/admin/QuizManagement.vue
@@ -146,7 +146,13 @@
         <v-btn @click="enrollUserIntoQuiz" block size="large" color="white" :disabled="loading"
           >ENROLL STUDENTS TO EXAM (UPLOAD CSV)<v-icon end icon="mdi-paperclip"></v-icon
         ></v-btn>
-        <v-file-input ref="csvUploadZone" class="d-none" type="file" accept=".csv" @input="handleCsvUpload" />
+        <v-file-input
+          ref="csvUploadZone"
+          class="d-none"
+          type="file"
+          accept=".csv"
+          @input="handleCsvUpload"
+        />
         <v-btn
           @click="downloadUserQuizzes"
           block

--- a/client/src/components/app/admin/UserManagement.vue
+++ b/client/src/components/app/admin/UserManagement.vue
@@ -145,7 +145,7 @@
 
 <script lang="ts">
 import {
-  deleteUsersMutation,
+  deleteUserMutation,
   addUserMutation,
   successMessage,
   downloadUsersCsvQuery
@@ -422,7 +422,7 @@ export default {
           this.students = await parseCSVPapaparse(this.deleteCsv)
 
           const deletionPromises = this.students.map(async (student) => {
-            const success = await deleteUsersMutation(this.$apollo, student.email)
+            const success = await deleteUserMutation(this.$apollo, student.email)
             console.log(`Delete success: ${success} for ${student.email}`)
             return success
           })

--- a/client/src/components/app/admin/UserManagement.vue
+++ b/client/src/components/app/admin/UserManagement.vue
@@ -384,7 +384,7 @@ export default {
         this.loading = true // Show the loading bar
         this.popUpDialog = true
         const deletionPromises = this.currentEmails.map(async (email: string) => {
-          const success = await deleteUsersMutation(this.$apollo, email)
+          const success = await deleteUserMutation(this.$apollo, email)
           console.log(`Delete success: ${success} for ${email}`)
 
           if (success) {

--- a/client/src/gql/mutations/userQuiz.ts
+++ b/client/src/gql/mutations/userQuiz.ts
@@ -44,3 +44,9 @@ export const EnrolUsersInQuizMutation = gql`
     }
   }
 `
+export const UnenrolUsersFromQuizMutation = gql`
+  mutation UnenrolUsersFromQuiz($users: [UsersInput!]!, $quizId: ID!) {
+    unenrolUsersFromQuiz(users: $users, quizID: $quizId) {
+    }
+  }
+`

--- a/client/src/gql/mutations/userQuiz.ts
+++ b/client/src/gql/mutations/userQuiz.ts
@@ -46,7 +46,7 @@ export const EnrolUsersInQuizMutation = gql`
 `
 export const UnenrolUsersFromQuizMutation = gql`
   mutation UnenrolUsersFromQuiz($users: [UsersInput!]!, $quizId: ID!) {
-    unenrolUsersFromQuiz(users: $users, quizID: $quizId) {
-    }
+    unenrolUsersFromQuiz(users: $users, quizID: $quizId)
   }
-`
+`;
+

--- a/client/src/utils/userManagement.ts
+++ b/client/src/utils/userManagement.ts
@@ -1,7 +1,8 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { AddUserMutation } from '../gql/mutations/addUsers'
 import { GetUserListQuery } from '../gql/queries/userList'
-import { DeleteUserMutation } from '../gql/mutations/deleteUsers'
+import { DeleteUserMutation, } from '../gql/mutations/deleteUsers'
+import { UnenrolUsersFromQuizMutation } from '../gql/mutations/userQuiz'
 
 export const addUserMutation = async (
   apollo: ApolloClient<NormalizedCacheObject>,
@@ -35,7 +36,7 @@ export const addUserMutation = async (
   }
 }
 
-export const deleteUsersMutation = async (
+export const deleteUserMutation = async (
   apollo: ApolloClient<NormalizedCacheObject>,
   email: string
 ): Promise<boolean> => {
@@ -47,6 +48,19 @@ export const deleteUsersMutation = async (
       }
     })
     const deletedEmail = mutation.data.deleteUser.email
+    // delete all associated user quizzes
+    console.log("Trying to delete user quizzes")
+    const deleteUserQuizzesMutation = await apollo.mutate({
+      mutation: UnenrolUsersFromQuizMutation,
+      variables: {
+        users: {
+          id: mutation.data.deleteUser.id,
+        },
+        quizId: null
+      }
+    })
+    console.log("Deleted user quizzes")
+    console.log(deleteUserQuizzesMutation.data)
     return deletedEmail === email.toLowerCase()
   } catch (e) {
     console.error(e)

--- a/client/src/utils/userManagement.ts
+++ b/client/src/utils/userManagement.ts
@@ -53,10 +53,12 @@ export const deleteUserMutation = async (
     const deleteUserQuizzesMutation = await apollo.mutate({
       mutation: UnenrolUsersFromQuizMutation,
       variables: {
-        users: {
-          id: mutation.data.deleteUser.id,
-        },
-        quizId: null
+        users: [
+          {
+            id: mutation.data.deleteUser.id
+          }
+        ],
+        quizId: "all"
       }
     })
     console.log("Deleted user quizzes")

--- a/service/src/controllers/userQuiz.ts
+++ b/service/src/controllers/userQuiz.ts
@@ -249,14 +249,26 @@ const editUserQuiz = async (
 }
 const deleteUserQuiz = async (quizid: string, userid: string) => {
     try {
+
         // Query 'userquizs' collection with the given parameters
         let userQuizID: string | null = null // Initialize with a default value
-
-        const querySnapshot = await firestore
-            .collection('UserQuizs')
-            .where('quizID', '==', quizid)
-            .where('userID', '==', userid)
-            .get()
+        let querySnapshot: FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData> | null = null
+        console.log(`Deleting for user ${userid} and quiz ${quizid}`)
+        if (quizid === null && userid !== null) {
+            // delete all userquizs for a user
+            querySnapshot = await firestore
+                .collection('UserQuizs')
+                .where('userID', '==', userid)
+                .get()
+        }
+        else {
+            // delete a user quiz for a given quiz and user
+            querySnapshot = await firestore
+                .collection('UserQuizs')
+                .where('quizID', '==', quizid)
+                .where('userID', '==', userid)
+                .get()
+            }
 
         // Delete each matching document
         const deletePromises: Promise<WriteResult>[] = []
@@ -267,14 +279,14 @@ const deleteUserQuiz = async (quizid: string, userid: string) => {
 
         // Wait for all deletions to complete
         await Promise.all(deletePromises)
-
+        
         if (userQuizID === null) {
             // Handle the case when no matching documents are found
             console.log('No matching documents found.')
             return null
         }
-
         console.log('Documents successfully deleted!')
+        console.log(`Amount of deleted quizzes: ${deletePromises.length}`)
         return userQuizID
     } catch (error) {
         console.error('Error deleting documents:', error)

--- a/service/src/controllers/userQuiz.ts
+++ b/service/src/controllers/userQuiz.ts
@@ -254,7 +254,7 @@ const deleteUserQuiz = async (quizid: string, userid: string) => {
         let userQuizID: string | null = null // Initialize with a default value
         let querySnapshot: FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData> | null = null
         console.log(`Deleting for user ${userid} and quiz ${quizid}`)
-        if (quizid === null && userid !== null) {
+        if (quizid == "all" && userid !== null) {
             // delete all userquizs for a user
             querySnapshot = await firestore
                 .collection('UserQuizs')


### PR DESCRIPTION
**Issue**

User quizzes still existed even though users were removed from the database

Closes #409 

**Solution**
Implemented cascading deletion for user's so their user quizzes are also deleted

<!-- **Discussion** -->
This ticket also required user quizzes to be deleted upon deletion of an exam (quiz), however, the functionality to delete a quiz has not been implemented in the client side yet.

**Risks**

u might delete all the user quizzes (jk 👀)

**Reviewers**

@johnchen383 
@bcho892 