### PR TITLE
fix: :bug: remove downtime during exams and exam management

### DIFF
--- a/client/src/components/app/admin/QuizManagement.vue
+++ b/client/src/components/app/admin/QuizManagement.vue
@@ -15,7 +15,13 @@
       <v-card-title class="popup-headline">NZPMC Admin</v-card-title>
       <v-card-text class="popup-text">
         <div class="custom-progress">
-          <v-progress-circular v-if="loading" :size="100" :width="15" color="primary" indeterminate></v-progress-circular>
+          <v-progress-circular
+            v-if="loading"
+            :size="100"
+            :width="15"
+            color="primary"
+            indeterminate
+          ></v-progress-circular>
           <!-- <temp> -->
 
           <template v-else>
@@ -31,8 +37,15 @@
 
   <v-container class="quiz-management" fluid>
     <v-container fluid>
-      <v-select :disabled="loading" v-model="quizIdInput" label="SELECT AN EXAM" :items="quizzes" item-title="name"
-        item-value="id" @update:model-value="updateQuizID"></v-select>
+      <v-select
+        :disabled="loading"
+        v-model="quizIdInput"
+        label="SELECT AN EXAM"
+        :items="quizzes"
+        item-title="name"
+        item-value="id"
+        @update:model-value="updateQuizID"
+      ></v-select>
 
       <v-btn :disabled="loading" size="large" color="secondary" @click="createAndGoToExam">
         ADD NEW EXAM
@@ -48,57 +61,124 @@
           </h2>
           <p><b>Last Modified: </b>{{ quizLastModified }}</p>
         </div>
-        <v-text-field label="ID" :model-value="quizIdInput" class="id-input" density="comfortable"
-          readonly></v-text-field>
+        <v-text-field
+          label="ID"
+          :model-value="quizIdInput"
+          class="id-input"
+          density="comfortable"
+          readonly
+        ></v-text-field>
       </div>
-      <v-text-field label="Exam Name" :disabled="loading" @change="handleNameChange"
-        :model-value="quizName"></v-text-field>
-      <v-textarea label="Description" auto-grow @change="handleDescriptionChange" :disabled="loading"
-        :model-value="quizDescription" rows="3" clearable></v-textarea>
+      <v-text-field
+        label="Exam Name"
+        :disabled="loading"
+        @change="handleNameChange"
+        :model-value="quizName"
+      ></v-text-field>
+      <v-textarea
+        label="Description"
+        auto-grow
+        @change="handleDescriptionChange"
+        :disabled="loading"
+        :model-value="quizDescription"
+        rows="3"
+        clearable
+      ></v-textarea>
 
       <v-divider :thickness="3" class="pa-5" />
 
-      <v-text-field type="number" @change="handleDurationChange" :disabled="loading" label="Exam Time (minutes)"
-        :model-value="quizDurationMinutes"></v-text-field>
+      <v-text-field
+        type="number"
+        @change="handleDurationChange"
+        :disabled="loading"
+        label="Exam Time (minutes)"
+        :model-value="quizDurationMinutes"
+      ></v-text-field>
 
       <v-divider :thickness="3" class="pa-5" />
 
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field :disabled="loading" label="Open Date" type="date" prepend-inner-icon="mdi-calendar-range"
-            @change="handleOpenDateChange" :model-value="quizStartDate"></v-text-field>
-          <v-text-field label="Open Time" :disabled="loading" type="time"
-            prepend-inner-icon="mdi-clock-time-eight-outline" @change="handleOpenTimeChange"
-            :model-value="quizStartTime"></v-text-field>
+          <v-text-field
+            :disabled="loading"
+            label="Open Date"
+            type="date"
+            prepend-inner-icon="mdi-calendar-range"
+            @change="handleOpenDateChange"
+            :model-value="quizStartDate"
+          ></v-text-field>
+          <v-text-field
+            label="Open Time"
+            :disabled="loading"
+            type="time"
+            prepend-inner-icon="mdi-clock-time-eight-outline"
+            @change="handleOpenTimeChange"
+            :model-value="quizStartTime"
+          ></v-text-field>
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field label="Close Date" :disabled="loading" type="date" :model-value="quizEndDate"
-            @change="handleCloseDateChange" prepend-inner-icon="mdi-calendar-range"></v-text-field>
-          <v-text-field label="Close Time" :disabled="loading" type="time"
-            prepend-inner-icon="mdi-clock-time-eight-outline" @change="handleCloseTimeChange"
-            :model-value="quizEndTime"></v-text-field>
+          <v-text-field
+            label="Close Date"
+            :disabled="loading"
+            type="date"
+            :model-value="quizEndDate"
+            @change="handleCloseDateChange"
+            prepend-inner-icon="mdi-calendar-range"
+          ></v-text-field>
+          <v-text-field
+            label="Close Time"
+            :disabled="loading"
+            type="time"
+            prepend-inner-icon="mdi-clock-time-eight-outline"
+            @change="handleCloseTimeChange"
+            :model-value="quizEndTime"
+          ></v-text-field>
         </v-col>
       </v-row>
 
       <v-container fluid class="px-0">
-        <v-btn size="large" :disabled="loading" color="blue-darken-2" @click="showEditQuestionPopUp">EDIT QUESTIONS<v-icon
-            end icon="mdi-cog"></v-icon></v-btn>
+        <v-btn size="large" :disabled="loading" color="blue-darken-2" @click="showEditQuestionPopUp"
+          >EDIT QUESTIONS<v-icon end icon="mdi-cog"></v-icon
+        ></v-btn>
       </v-container>
 
       <v-container fluid class="px-0 mt-5">
-        <v-btn @click="enrollUserIntoQuiz" block size="large" color="white" :disabled="loading">ENROLL STUDENTS TO EXAM
-          (UPLOAD CSV)<v-icon end icon="mdi-paperclip"></v-icon></v-btn>
-        <v-file-input ref="csvUploadZone" class="d-none" type="file" accept=".csv" @change="handleCsvUpload" />
-        <v-btn @click="downloadUserQuizzes" block size="large" color="blue-darken-2" class="mt-3"
-          :disabled="loading">DOWNLOAD USERS CSV OF CURRENT EXAM</v-btn>
-        <v-btn @click="deleteCurrentExam" block size="large" color="red" class="mt-3" :disabled="loading">
+        <v-btn @click="enrollUserIntoQuiz" block size="large" color="white" :disabled="loading"
+          >ENROLL STUDENTS TO EXAM (UPLOAD CSV)<v-icon end icon="mdi-paperclip"></v-icon
+        ></v-btn>
+        <v-file-input
+          ref="csvUploadZone"
+          class="d-none"
+          type="file"
+          accept=".csv"
+          @change="handleCsvUpload"
+        />
+        <v-btn
+          @click="downloadUserQuizzes"
+          block
+          size="large"
+          color="blue-darken-2"
+          class="mt-3"
+          :disabled="loading"
+          >DOWNLOAD USERS CSV OF CURRENT EXAM</v-btn
+        >
+        <v-btn
+          @click="deleteCurrentExam"
+          block
+          size="large"
+          color="red"
+          class="mt-3"
+          :disabled="loading"
+        >
           DELETE CURRENT EXAM
         </v-btn>
       </v-container>
 
       <v-container fluid class="px-0 mt-5">
         <v-btn block size="large" :disabled="loading" color="secondary">GRADE EXAM</v-btn>
-        <v-btn block size="large" :disabled="loading" color="secondary" class="mt-3">RELEASE RESULTS</v-btn>
+        <v-btn block size="large" :disabled="loading" color="secondary" class="mt-3"
+          >RELEASE RESULTS</v-btn
+        >
       </v-container>
     </v-container>
   </v-container>
@@ -158,8 +238,8 @@ export default defineComponent({
       uploadedCsv: null,
       confirmationDialog: false,
       confirmationMessage: '',
-      confirmAction: () => { },
-      cancelAction: () => { }
+      confirmAction: () => {},
+      cancelAction: () => {}
     }
   },
 

--- a/client/src/components/app/admin/QuizManagement.vue
+++ b/client/src/components/app/admin/QuizManagement.vue
@@ -15,13 +15,7 @@
       <v-card-title class="popup-headline">NZPMC Admin</v-card-title>
       <v-card-text class="popup-text">
         <div class="custom-progress">
-          <v-progress-circular
-            v-if="loading"
-            :size="100"
-            :width="15"
-            color="primary"
-            indeterminate
-          ></v-progress-circular>
+          <v-progress-circular v-if="loading" :size="100" :width="15" color="primary" indeterminate></v-progress-circular>
           <!-- <temp> -->
 
           <template v-else>
@@ -37,15 +31,8 @@
 
   <v-container class="quiz-management" fluid>
     <v-container fluid>
-      <v-select
-        :disabled="loading"
-        v-model="quizIdInput"
-        label="SELECT AN EXAM"
-        :items="quizzes"
-        item-title="name"
-        item-value="id"
-        @update:model-value="updateQuizID"
-      ></v-select>
+      <v-select :disabled="loading" v-model="quizIdInput" label="SELECT AN EXAM" :items="quizzes" item-title="name"
+        item-value="id" @update:model-value="updateQuizID"></v-select>
 
       <v-btn :disabled="loading" size="large" color="secondary" @click="createAndGoToExam">
         ADD NEW EXAM
@@ -61,124 +48,57 @@
           </h2>
           <p><b>Last Modified: </b>{{ quizLastModified }}</p>
         </div>
-        <v-text-field
-          label="ID"
-          :model-value="quizIdInput"
-          class="id-input"
-          density="comfortable"
-          readonly
-        ></v-text-field>
+        <v-text-field label="ID" :model-value="quizIdInput" class="id-input" density="comfortable"
+          readonly></v-text-field>
       </div>
-      <v-text-field
-        label="Exam Name"
-        :disabled="loading"
-        @change="handleNameChange"
-        :model-value="quizName"
-      ></v-text-field>
-      <v-textarea
-        label="Description"
-        auto-grow
-        @change="handleDescriptionChange"
-        :disabled="loading"
-        :model-value="quizDescription"
-        rows="3"
-        clearable
-      ></v-textarea>
+      <v-text-field label="Exam Name" :disabled="loading" @change="handleNameChange"
+        :model-value="quizName"></v-text-field>
+      <v-textarea label="Description" auto-grow @change="handleDescriptionChange" :disabled="loading"
+        :model-value="quizDescription" rows="3" clearable></v-textarea>
 
       <v-divider :thickness="3" class="pa-5" />
 
-      <v-text-field
-        type="number"
-        @change="handleDurationChange"
-        :disabled="loading"
-        label="Exam Time (minutes)"
-        :model-value="quizDurationMinutes"
-      ></v-text-field>
+      <v-text-field type="number" @change="handleDurationChange" :disabled="loading" label="Exam Time (minutes)"
+        :model-value="quizDurationMinutes"></v-text-field>
 
       <v-divider :thickness="3" class="pa-5" />
 
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field
-            :disabled="loading"
-            label="Open Date"
-            type="date"
-            prepend-inner-icon="mdi-calendar-range"
-            @change="handleOpenDateChange"
-            :model-value="quizStartDate"
-          ></v-text-field>
-          <v-text-field
-            label="Open Time"
-            :disabled="loading"
-            type="time"
-            prepend-inner-icon="mdi-clock-time-eight-outline"
-            @change="handleOpenTimeChange"
-            :model-value="quizStartTime"
-          ></v-text-field>
+          <v-text-field :disabled="loading" label="Open Date" type="date" prepend-inner-icon="mdi-calendar-range"
+            @change="handleOpenDateChange" :model-value="quizStartDate"></v-text-field>
+          <v-text-field label="Open Time" :disabled="loading" type="time"
+            prepend-inner-icon="mdi-clock-time-eight-outline" @change="handleOpenTimeChange"
+            :model-value="quizStartTime"></v-text-field>
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-            label="Close Date"
-            :disabled="loading"
-            type="date"
-            :model-value="quizEndDate"
-            @change="handleCloseDateChange"
-            prepend-inner-icon="mdi-calendar-range"
-          ></v-text-field>
-          <v-text-field
-            label="Close Time"
-            :disabled="loading"
-            type="time"
-            prepend-inner-icon="mdi-clock-time-eight-outline"
-            @change="handleCloseTimeChange"
-            :model-value="quizEndTime"
-          ></v-text-field>
+          <v-text-field label="Close Date" :disabled="loading" type="date" :model-value="quizEndDate"
+            @change="handleCloseDateChange" prepend-inner-icon="mdi-calendar-range"></v-text-field>
+          <v-text-field label="Close Time" :disabled="loading" type="time"
+            prepend-inner-icon="mdi-clock-time-eight-outline" @change="handleCloseTimeChange"
+            :model-value="quizEndTime"></v-text-field>
         </v-col>
       </v-row>
 
       <v-container fluid class="px-0">
-        <v-btn size="large" :disabled="loading" color="blue-darken-2" @click="showEditQuestionPopUp"
-          >EDIT QUESTIONS<v-icon end icon="mdi-cog"></v-icon
-        ></v-btn>
+        <v-btn size="large" :disabled="loading" color="blue-darken-2" @click="showEditQuestionPopUp">EDIT QUESTIONS<v-icon
+            end icon="mdi-cog"></v-icon></v-btn>
       </v-container>
 
       <v-container fluid class="px-0 mt-5">
-        <v-btn @click="enrollUserIntoQuiz" block size="large" color="white" :disabled="loading"
-          >ENROLL STUDENTS TO EXAM (UPLOAD CSV)<v-icon end icon="mdi-paperclip"></v-icon
-        ></v-btn>
-        <v-file-input
-          ref="csvUploadZone"
-          class="d-none"
-          type="file"
-          accept=".csv"
-          @change="handleCsvUpload"
-        />
-        <v-btn
-          @click="downloadUserQuizzes"
-          block
-          size="large"
-          color="blue-darken-2"
-          class="mt-3"
-          :disabled="loading"
-          >DOWNLOAD USERS CSV OF CURRENT EXAM</v-btn
-        >
-        <v-btn
-          @click="deleteCurrentExam"
-          block
-          size="large"
-          color="red"
-          class="mt-3"
-          :disabled="loading"
-        >
+        <v-btn @click="enrollUserIntoQuiz" block size="large" color="white" :disabled="loading">ENROLL STUDENTS TO EXAM
+          (UPLOAD CSV)<v-icon end icon="mdi-paperclip"></v-icon></v-btn>
+        <v-file-input ref="csvUploadZone" class="d-none" type="file" accept=".csv" @change="handleCsvUpload" />
+        <v-btn @click="downloadUserQuizzes" block size="large" color="blue-darken-2" class="mt-3"
+          :disabled="loading">DOWNLOAD USERS CSV OF CURRENT EXAM</v-btn>
+        <v-btn @click="deleteCurrentExam" block size="large" color="red" class="mt-3" :disabled="loading">
           DELETE CURRENT EXAM
         </v-btn>
       </v-container>
 
       <v-container fluid class="px-0 mt-5">
         <v-btn block size="large" :disabled="loading" color="secondary">GRADE EXAM</v-btn>
-        <v-btn block size="large" :disabled="loading" color="secondary" class="mt-3"
-          >RELEASE RESULTS</v-btn
-        >
+        <v-btn block size="large" :disabled="loading" color="secondary" class="mt-3">RELEASE RESULTS</v-btn>
       </v-container>
     </v-container>
   </v-container>
@@ -238,8 +158,8 @@ export default defineComponent({
       uploadedCsv: null,
       confirmationDialog: false,
       confirmationMessage: '',
-      confirmAction: () => {},
-      cancelAction: () => {}
+      confirmAction: () => { },
+      cancelAction: () => { }
     }
   },
 
@@ -479,13 +399,11 @@ export default defineComponent({
     },
     async editAndUpdateSelectedQuiz(id: string, input: editQuizInput) {
       const debouncedEdit = debounce(editQuizMutation)
-      this.loading = true
       const res = await debouncedEdit(this.$apollo, id, input)
       this.selectedQuiz = { ...this.selectedQuiz, modified: res.modified }
       if (input.name !== undefined) {
         await this.$apollo.queries.userQuizzes.refetch()
       }
-      this.loading = false
     },
     async enrollUserIntoQuiz() {
       try {
@@ -588,14 +506,17 @@ export default defineComponent({
   width: 600px;
   max-width: 100%;
 }
+
 .popup-headline {
   text-align: center;
 }
+
 .popup-text {
   font-size: 1.5rem;
   text-align: center;
   white-space: pre-line;
 }
+
 .popup-button {
   margin: 0 auto;
   display: block;

--- a/client/src/components/app/exam/Question/FlagButton.vue
+++ b/client/src/components/app/exam/Question/FlagButton.vue
@@ -1,13 +1,7 @@
 <template>
   <v-tooltip left class="app-exam-question-flag-button">
     <template #activator="{ on, attrs }">
-      <v-btn
-        icon
-        :color="currentFlagged ? 'red' : undefined"
-        v-bind="attrs"
-        v-on="on"
-        @click="toggle"
-      >
+      <v-btn icon :color="currentFlagged ? 'red' : undefined" v-bind="attrs" v-on="on" @click="toggle">
         <v-icon>{{ currentFlagged ? 'mdi-flag' : 'mdi-flag-outline' }}</v-icon>
       </v-btn>
     </template>
@@ -77,14 +71,13 @@ export default {
 
       mutation
         .then(() => {
-          this.$emit('ready-to-fetch')
         })
         .catch(() => {
           this.snackbarQueue.push(
-            `An error occured when ${this.flagged ? 'unflagging' : 'flagging'} Question ${
-              this.questionNumber
+            `An error occured when ${this.flagged ? 'unflagging' : 'flagging'} Question ${this.questionNumber
             }. Please check your connection and try again.`
           )
+          this.$emit('ready-to-fetch')
         })
     }
   }

--- a/client/src/components/app/exam/Question/Options.vue
+++ b/client/src/components/app/exam/Question/Options.vue
@@ -9,58 +9,30 @@
 <template>
   <v-item-group v-model="selected" class="options-container">
     <v-item v-for="(option, index) in sortedOptions" :key="option.id" v-slot="{ active, toggle }">
-      <v-card
-        elevation="1"
-        :dark="active"
-        :color="getCardColor(option)"
-        :ripple="!isAdminAndEditing"
-        :disabled="updating || review"
-        class="align-center d-flex mb-3"
-        @click="!isAdminAndEditing && setSelected(option.id)"
-        @keyup.enter="!isAdminAndEditing && toggle"
-      >
+      <v-card elevation="1" :dark="active" :color="getCardColor(option)" :ripple="!isAdminAndEditing"
+        :disabled="updating || review" class="align-center d-flex mb-3"
+        @click="!isAdminAndEditing && setSelected(option.id)" @keyup.enter="!isAdminAndEditing && toggle">
         <h3 v-if="isAdminAndEditing" class="ml-4 my-4">{{ index + 1 }}.</h3>
         <v-icon v-else class="ml-4 my-4">
           {{ isSelected(option.id) ? 'mdi-check-circle' : 'mdi-checkbox-blank-circle-outline' }}
         </v-icon>
 
         <span class="d-block pa-4" style="width: calc(100% - 3.5rem)">
-          <v-text-field
-            :hint="'Modified: ' + option.modified"
-            persistent-hint
-            variant="underlined"
-            @change="handleOptionDescriptionChange(option.id, $event)"
-            :model-value="option.option"
-            v-if="isAdminAndEditing"
-          ></v-text-field>
+          <v-text-field :hint="'Modified: ' + option.modified" persistent-hint variant="underlined"
+            @change="handleOptionDescriptionChange(option.id, $event)" :model-value="option.option"
+            v-if="isAdminAndEditing"></v-text-field>
           <span v-else>{{ option.option }}</span>
         </span>
-        <v-btn
-          elevation="0"
-          v-if="isAdminAndEditing"
-          v-on:click="deleteOption(option.id)"
-          color="red"
-          icon="mdi-close"
-          class="mr-4 my-4"
-        />
-        <v-btn
-          elevation="0"
-          v-if="isAdminAndEditing"
-          v-on:click="handleCorrectAnswerChange(option.id)"
+        <v-btn elevation="0" v-if="isAdminAndEditing" v-on:click="deleteOption(option.id)" color="red" icon="mdi-close"
+          class="mr-4 my-4" />
+        <v-btn elevation="0" v-if="isAdminAndEditing" v-on:click="handleCorrectAnswerChange(option.id)"
           :color="isCorrectAnswer(option.id) ? 'accent' : 'secondary'"
-          :icon="isCorrectAnswer(option.id) ? 'mdi-check-circle' : 'mdi-cancel'"
-          class="mr-4 my-4"
-        />
+          :icon="isCorrectAnswer(option.id) ? 'mdi-check-circle' : 'mdi-cancel'" class="mr-4 my-4" />
       </v-card>
     </v-item>
     <v-item v-if="isAdminAndEditing">
-      <v-card
-        elevation="1"
-        :ripple="!isAdminAndEditing"
-        class="align-center d-flex mb-3"
-        @click="addNewOption"
-        :disabled="updating"
-      >
+      <v-card elevation="1" :ripple="!isAdminAndEditing" class="align-center d-flex mb-3" @click="addNewOption"
+        :disabled="updating">
         <v-icon class="ml-4 my-4">
           {{ 'mdi-plus-circle' }}
         </v-icon>
@@ -207,11 +179,11 @@ export default {
           this.snackbarQueue.push(
             `An error occured when saving your answer for Question ${this.questionNumber}. Please check your connection and try again.`
           )
+          this.$emit('ready-to-fetch')
         })
         .finally(() => {
           // Ensure selected state is synced with server
           console.log('Success')
-          this.$emit('ready-to-fetch')
         })
     }
   },


### PR DESCRIPTION
**Issue**

<!-- Explain why you're making the change you are, what is the problem this PR solves? -->

Closes #419 

- The disabling of the exam panel caused some issues with UX 
- Fetching data from firebase and updating the exam options and flag also caused UX issues

**Solution**

<!-- Help the reviewer out! List the changes you've made and potentially why. -->
<!-- If it makes more sense to comment on specific lines, do so but also let the reviewer know here. -->\
We will only refetch if the mutation failed

Exam panel no downtime:

![exam](https://github.com/UoaWDCC/nzpmc-exam-portal/assets/100653148/fe80bbd9-91a6-4e18-b6f8-28588f9feb2a)

Quiz Management & Type in date and time:

![management](https://github.com/UoaWDCC/nzpmc-exam-portal/assets/100653148/7a55eb88-8fca-44d1-a337-209b40e0ae57)
